### PR TITLE
gemファイルのバージョンの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.1'
+# ruby '2.5.1'
 
 gem "refile", require: "refile/rails", github: 'manfe/refile'
 gem "refile-mini_magick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,8 +321,5 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
-RUBY VERSION
-   ruby 2.5.1p57
-
 BUNDLED WITH
-   1.16.5
+   1.17.1


### PR DESCRIPTION
rubyのバージョンが合わなくてターミナルが使えなかったので、gemfileのruby '2.5.1'をコメントアウトしました。