### PR TITLE
退会ページの論理削除

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,5 +321,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
 
+RUBY VERSION
+   ruby 2.5.1p57
+
 BUNDLED WITH
    1.17.1

--- a/app/controllers/address_lines_controller.rb
+++ b/app/controllers/address_lines_controller.rb
@@ -19,7 +19,7 @@ class AddressLinesController < ApplicationController
   end
 
   def update
-     @addressline = AddressLine.find(params[:id])
+    @addressline = AddressLine.find(params[:id])
     @addressline.user_id = current_user.id
     @addressline.update(addressline_params)
     redirect_to user_path(current_user.id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,23 +4,28 @@ class UsersController < ApplicationController
 
 
   def show
-    @user = User.find(params[:id])
+    @user = User.active
   end
 
   def edit
-    @user = User.find(params[:id])
+    @user = User.active
   end
 
   def update
-      @user = User.find(params[:id])
-      # @user.id = current_user.id
+      @user = User.active
+      # @user.id = current_user.
     @user.update(user_params)
     redirect_to @user
   end
 
   def resignnation
      @user = current_user
-     @user.update(delete_flag:true)
+     p session.to_hash
+     @user.update(delete_flag: true)
+     @user.errors.full_messages
+  end
+
+  def complete
   end
 end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,5 @@ class User < ApplicationRecord
     ユーザー: false,
     退会ユーザー: true
   }
+scope :active, -> { find_by(delete_flag: false) }
 end

--- a/app/views/address_lines/new.html.erb
+++ b/app/views/address_lines/new.html.erb
@@ -5,16 +5,16 @@
 </head>
 <body>
 	<h1>AddressLines#new</h1>
-	<%= form_for(@addressline) do |f| %>
+	<%= form_for(@addressline) do |s| %>
 	<h4>郵便番号</h4>
-	    <%= f.text_field :postcode %>
-	    <%= render 'address_lines/form',f:f %>
+	    <%= s.text_field :postcode %>
+	    <%= render 'address_lines/form',s:s %>
 	    <!-- 都道府県を選択するformです -->
 	    <h4>市・町・村</h4>
-	    <%= f.text_field :city %>
+	    <%= s.text_field :city %>
 	    <h4>建物名・番地</h4>
-	    <%= f.text_field :address %>
-	    <%= f.submit '登録' %>
+	    <%= s.text_field :address %>
+	    <%= s.submit '登録' %>
  	<% end %>
 </body>
 </html> 

--- a/app/views/users/complete.html.erb
+++ b/app/views/users/complete.html.erb
@@ -1,0 +1,3 @@
+<h2>退会手続きが完了しました</h2>
+<%= link_to"TOPへ戻る", "#" %>
+ <li><%= link_to " logout", destroy_user_session_path, class: "glyphicon glyphicon-log-out logout", method: :delete %></li>

--- a/app/views/users/resignnation.html.erb
+++ b/app/views/users/resignnation.html.erb
@@ -21,11 +21,11 @@
 									<h4 class="modal-title">本当に退会してよろしいですか？</h4>
 								</div>
 								<div class="modal-body">
-									<h3 class="btn btn-warning">はい</h3><h3 class="btn btn-primary">いいえ</h3>
+									<%= link_to"はい", users_complete_path, class: "btn btn-warning btn-lg" %>
+								<h3 class="btn btn-primary btn-lg">いいえ</h3>
 								</div>
 								<div class="modal-footer">
 									<button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-									<button type="button" class="btn btn-primary">ボタン</button>
 								</div>
 							</div>
 						</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,7 +14,7 @@
 						<ul class="list-group">
 							<% @user.address_lines.each do |addressline| %>
 							<li class="list-group-item list-group-item-info" style="text-align: center"><strong>ユーザープロフィール</strong></li>
-							<li class="list-group-item"><strong>ユーザーネーム</strong>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<%= current_user.full_name %></li>
+							<li class="list-group-item"><strong>ユーザーネーム</strong>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<%= @user.full_name %></li>
 							<li class="list-group-item"><strong>ユーザーネーム(カナ)</strong>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<%= @user.full_name_kana %></li>
 							<li class="list-group-item"><strong>メールアドレス</strong>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <%= @user.email %></li>
 							<li class="list-group-item"><strong>電話番号</strong>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <%= @user.telephone %></li>
@@ -26,9 +26,7 @@
 						</ul>
 					</div>
 					<div>
-						<% if @user.id == current_user.id %>
 		        		<p><%= link_to "プロフィール編集", edit_user_path(@user), class: "btn btn-success " %></p>
-		        		<% end %>
 					</div>
 			</div>
 		</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
   resources :favorites, :only =>[:create,:destroy,:index]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   get 'users/resignnation'
-  resources :users,:except =>[:new,:create,:destroy]
+  get 'users/complete'
+  resources :users,:except =>[:new,:create,]
 
 end

--- a/db/migrate/20181119052611_remove_delete_from_users.rb
+++ b/db/migrate/20181119052611_remove_delete_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveDeleteFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :delete_flag, :boolean
+  end
+end

--- a/db/migrate/20181119052957_add_delete_to_users.rb
+++ b/db/migrate/20181119052957_add_delete_to_users.rb
@@ -1,0 +1,5 @@
+class AddDeleteToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :delete_flag,:boolean,default:false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_14_075425) do
+ActiveRecord::Schema.define(version: 2018_11_19_052957) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -88,7 +88,6 @@ ActiveRecord::Schema.define(version: 2018_11_14_075425) do
   create_table "cd_products", force: :cascade do |t|
     t.string "name"
     t.string "price"
-    t.string "integer"
     t.integer "label_id"
     t.integer "stock_number"
     t.integer "release_era_tag_id"
@@ -105,7 +104,6 @@ ActiveRecord::Schema.define(version: 2018_11_14_075425) do
 
   create_table "companies", force: :cascade do |t|
     t.string "company"
-    t.integer "goods_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -165,6 +163,7 @@ ActiveRecord::Schema.define(version: 2018_11_14_075425) do
   end
 
   create_table "release_era_tags", force: :cascade do |t|
+    t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -212,7 +211,7 @@ ActiveRecord::Schema.define(version: 2018_11_14_075425) do
     t.string "last_name_kana"
     t.string "telephone"
     t.integer "address_line_id"
-    t.boolean "delete_flag"
+    t.boolean "delete_flag", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
bundle install しなおしたらgemlockの順番が入れ替わり、差異としてrubyのバージョンが出でてますが現在マージされてる分と同じバージョンなので特に影響ないと思います。コンフリクトは一応ないです。
退会ページで退会(論理削除)出来るよう修正。